### PR TITLE
feature: log 기능 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,58 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+
+    <springProperty name="LOG_PATH" source="logging.file.path" defaultValue="logs"/>
+    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){green} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+
+    <!-- DEV 환경 -->
+    <springProfile name="dev">
+        <property name="LOG_DIR" value="${LOG_PATH}/dev"/>
+        <appender name="FILE_DEV" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_DIR}/application.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_DIR}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>7</maxHistory> <!-- 7일 보관 -->
+            </rollingPolicy>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <root level="DEBUG">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE_DEV"/>
+        </root>
+    </springProfile>
+
+    <!-- PROD 환경 -->
+    <springProfile name="prod">
+        <property name="LOG_DIR" value="${LOG_PATH}/prod"/>
+        <appender name="FILE_PROD" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_DIR}/application.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_DIR}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>60</maxHistory> <!-- 60일 보관 -->
+            </rollingPolicy>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE_PROD"/>
+        </root>
+    </springProfile>
+
+    <!-- 공통 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Changes
- logback-spring.xml custom
  - dev, prod profile을 지정해서 실행할 때를 대비해 미리 나눠놨습니다.
  - dev, prod 환경이 아직 없는 초기 개발단계에서 사용할 기본적인 공통 appender도 추가했습니다.
- 로그 패턴 색상, 날짜 포맷 custom
  - clr를 include해서 <property> 로 pattern를 저장해두고 dev, prod, basic log에 다 사용하게 했습니다.
  - ` <include resource="org/springframework/boot/logging/logback/defaults.xml" />`
  - `<property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:- ... .15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>`

## Background
개발을 앞서 log를 파일로 남겨야 하는 작업이 필요했다.

## Discuss
logback-spring.xml를 작성하는데 아직 많이 익숙하지 않아서 내용이 좀 복잡하게 느껴졌었는데,
꼭 필요한 태그만 기본적으로 외워놔도 편하게 느껴질 것 같습니다.

간단한 이슈였지만 log별 색상을 바꾸고 싶어서 {clr} 를 사용하고 싶었지만, include를 안하고 사용하려는 간단한 실수 때문에 시간을 약간 더 소비했습니다. xml 파일이라 간과한 부분이지만 뭐든 새로운 기능을 넣고싶을땐 include를 잘 확인하려고 합니다.

## related issue
Resolve: #1

## Execute
![image](https://github.com/user-attachments/assets/697fd563-9952-4637-bef0-e438313345e4)
INFO, WARN, ERROR에 각각 다른 색상으로 패턴을 나눈 결과

## Reference