### PR TITLE
feature: 로그아웃 (SignOut)

### DIFF
--- a/src/main/java/org/jnjeaaaat/snms/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/jnjeaaaat/snms/domain/auth/controller/AuthController.java
@@ -15,6 +15,8 @@ import org.jnjeaaaat.snms.domain.auth.service.CoolSmsService;
 import org.jnjeaaaat.snms.global.util.CookieUtil;
 import org.jnjeaaaat.snms.global.validator.annotation.ValidProviderName;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -65,6 +67,19 @@ public class AuthController {
         CookieUtil.addCookie(response, COOKIE_NAME, signInResponse.accessToken(), COOKIE_MAX_AGE);
 
         return ResponseEntity.ok(signInResponse);
+    }
+
+    // 로그아웃
+    @DeleteMapping("/sign-out")
+    public ResponseEntity<Void> singOut(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        @AuthenticationPrincipal UserDetails userDetails) {
+
+        logInfo(request, "로그아웃 요청");
+
+        authService.signOut(userDetails);
+        CookieUtil.deleteCookie(response, COOKIE_NAME);
+        return ResponseEntity.ok().build();
     }
 
     // 핸드폰 인증 번호 요청

--- a/src/main/java/org/jnjeaaaat/snms/domain/auth/service/AuthService.java
+++ b/src/main/java/org/jnjeaaaat/snms/domain/auth/service/AuthService.java
@@ -195,6 +195,11 @@ public class AuthService {
         );
     }
 
+    @Transactional
+    public void signOut(UserDetails userDetails) {
+        redisTokenRepository.deleteById(Long.valueOf(userDetails.getUsername()));
+    }
+
     private String signInAndGetAccessToken(Member member) {
         UserDetails userDetails = getUserDetails(member.getUid());
 

--- a/src/main/java/org/jnjeaaaat/snms/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/jnjeaaaat/snms/global/security/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.snms.global.security.jwt.exception.TokenException;
 import org.jnjeaaaat.snms.global.util.CookieUtil;
 import org.springframework.security.core.Authentication;
@@ -21,6 +22,7 @@ import static org.jnjeaaaat.snms.global.constant.CookieCons.COOKIE_MAX_AGE;
 import static org.jnjeaaaat.snms.global.constant.CookieCons.COOKIE_NAME;
 import static org.jnjeaaaat.snms.global.exception.ErrorCode.EMPTY_TOKEN;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -29,6 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/docs/**", // spring REST docs
             "/error",
             "/favicon.ico",
+            "/api/auth/check-uid",
             "/api/auth/sign-up", // 회원가입
             "/api/auth/sign-in", // 로그인
             "/api/auth/send-sms", // 인증번호 발송
@@ -37,7 +40,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/auth/verify-code", // 인증번호 확인
             "/api/auth/oauth/phone",
             "/",
-            "/api/**" // todo: delete
     };
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/org/jnjeaaaat/snms/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/jnjeaaaat/snms/global/security/jwt/JwtTokenProvider.java
@@ -109,9 +109,9 @@ public class JwtTokenProvider {
                 "",
                 Collections.singleton(
                         new SimpleGrantedAuthority(
-                                claims.get("KEY_ROLE").toString()
+                                claims.get(KEY_ROLE).toString()
                         )
-        ));
+                ));
 
         return new UsernamePasswordAuthenticationToken(
                 user,

--- a/src/main/java/org/jnjeaaaat/snms/global/util/CookieUtil.java
+++ b/src/main/java/org/jnjeaaaat/snms/global/util/CookieUtil.java
@@ -14,8 +14,7 @@ public class CookieUtil {
     public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(true)
-                // todo: true 로 변경
-                .secure(false)
+                .secure(false) // todo: true 로 변경
                 .path("/")
                 .sameSite("None")
                 .maxAge(maxAge)
@@ -35,5 +34,17 @@ public class CookieUtil {
         }
 
         return Optional.empty();
+    }
+
+    public static void deleteCookie(HttpServletResponse response, String name) {
+        ResponseCookie cookie = ResponseCookie.from(name)
+                .httpOnly(true)
+                .secure(false) // todo: true 로 변경
+                .path("/")
+                .sameSite("None")
+                .maxAge(0)
+                .build();
+
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/src/test/java/org/jnjeaaaat/snms/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/jnjeaaaat/snms/domain/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package org.jnjeaaaat.snms.domain.auth.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.jnjeaaaat.snms.domain.auth.dto.request.*;
 import org.jnjeaaaat.snms.domain.auth.dto.response.SignInResponse;
@@ -22,6 +23,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -35,6 +37,7 @@ import static org.springframework.restdocs.cookies.CookieDocumentation.responseC
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -452,6 +455,25 @@ class AuthControllerTest {
                     ));
         }
 
+    }
+
+    @Test
+    @DisplayName("[성공] 로그아웃")
+    void success_sign_out() throws Exception {
+        //given
+        //when
+        //then
+        mockMvc.perform(delete("/api/auth/sign-out")
+                        .cookie(new Cookie("access_token", "token"))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("auth/sign-out/success",
+                        preprocessRequest(prettyPrint()),
+                        commonResponsePreprocessor
+                ));
+
+        verify(authService).signOut(any(UserDetails.class));
     }
 
     @Test

--- a/src/test/java/org/jnjeaaaat/snms/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/jnjeaaaat/snms/domain/auth/service/AuthServiceTest.java
@@ -215,6 +215,17 @@ class AuthServiceTest {
         }
     }
 
+    @Test
+    @DisplayName("[성공] 로그아웃")
+    void test() {
+        //given
+        given(userDetails.getUsername()).willReturn(String.valueOf(1L));
+        //when
+        //then
+        assertThatCode(() -> authService.signOut(userDetails))
+                .doesNotThrowAnyException();
+    }
+
     @Nested
     @DisplayName("문자인증 인증코드 확인")
     class VerifyAuthCode {


### PR DESCRIPTION
## Changes
- AuthController, AuthService Signout Method 생성
  - `@AuthenticationPrincipal` 어노테이션으로 UserDetails 추출
  - `RedisTokenRepository` 에서 deleteById로 해당 사용자 토큰 삭제
- CookieUtils.deleteCookie() Method 생성
  - COOKIE_NAME "access_token" `maxAge(0)` 설정 후 setCookie로 쿠키 삭제처리
- Test Code 작성
  - `WithMockUser` 에 UserDetails 설정
  - header(new Cookie("access_token", "token")) 쿠키 설정

## Background
사용자가 직접 로그아웃 했을 때 Redis, Cookie의 엑세스 토큰을 삭제하기 위한 로그아웃 기능 추가

## Discuss
단순히 RedisRepository의 deleteById로 엑세스 토큰 자체를 삭제하는 방식으로 구현했지만
해당 "accessToken:BLACK_LIST" 로 저장하여 해당 accessToken을 사용하지 못하게 하는 방식도 있어서

어떤 방식이 좋을지 고민이 됐습니다.

## related issue
#26

## Execute
먼저 로그인 후 Set-Cookie에 엑세스 토큰 저장 확인
PostMan으로 테스트하면 해당 도메인 요청에 자동으로 Cookie값이 삽입되어 있어서 Header에 Bearer {token} 작업이 필요없음

### 1. 우선 로그인 후 쿠키 확인
<img width="996" alt="스크린샷 2025-06-15 오후 4 16 55" src="https://github.com/user-attachments/assets/485caedf-61fa-419e-990e-f2c0fa9f63b5" />

### 2. Request 생성 시 request Header의 Cookie 확인
<img width="1001" alt="스크린샷 2025-06-15 오후 4 19 28" src="https://github.com/user-attachments/assets/ed0fbb77-2051-460e-bb53-e7a81e3e6ac7" />

> 로그인 하고 받은 엑세스 토큰이랑 일치

### 3. 로그아웃 성공 후 Set-Cookie 삭제 확인
<img width="997" alt="image" src="https://github.com/user-attachments/assets/5c3bfb43-9031-4557-93b7-b7b106dc0080" />

### 4. Redis 서버 확인
![image](https://github.com/user-attachments/assets/f4958e3b-1da7-4137-a181-889f51ea8753)