### PR TITLE
feature: Follow Entity, RedisCountService 생성 redisTemplate.opsForValue().increment(key);

### DIFF
--- a/common/src/main/java/org/jnjeaaaat/global/exception/ErrorCode.java
+++ b/common/src/main/java/org/jnjeaaaat/global/exception/ErrorCode.java
@@ -29,6 +29,13 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER(NOT_FOUND, "사용자를 찾을 수 없습니다."),
     WRONG_PASSWORD(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
+    CANNOT_FOLLOW_SELF(BAD_REQUEST, "자신을 팔로우 할 수 없습니다."),
+    ALREADY_FOLLOWING_MEMBER(BAD_REQUEST, "이미 팔로우 중인 사용자입니다."),
+    FOLLOW_LIMIT_EXCEEDED(TOO_MANY_REQUESTS, "팔로우 요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+    NOT_FOUND_FOLLOW(NOT_FOUND, "팔로우 기록이 없습니다."),
+
+    BLOCK_LIMIT_EXCEEDED(TOO_MANY_REQUESTS, "차단 요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+
     ILLEGAL_OAUTH(BAD_REQUEST, "유효하지 않은 소셜 로그인 입니다."),
     NOT_FOUND_SOCIAL_LOGIN(BAD_REQUEST, "소셜 로그인 기록이 없습니다."),
 

--- a/user-service/src/main/java/org/jnjeaaaat/domain/member/controller/MemberController.java
+++ b/user-service/src/main/java/org/jnjeaaaat/domain/member/controller/MemberController.java
@@ -39,28 +39,28 @@ public class MemberController {
         );
     }
 
-    @PostMapping("/follow/{memberId}")
+    @PostMapping("/follow/{followMemberId}")
     public ResponseEntity<Void> followMember(
             HttpServletRequest request,
             @AuthenticationPrincipal UserDetails userDetails,
-            @PathVariable Long memberId) {
+            @PathVariable Long followMemberId) {
 
         logInfo(request, "사용자 팔로우");
 
-        memberService.followMember(userDetails, memberId);
+        memberService.followMember(userDetails, followMemberId);
 
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/unfollow/{memberId}")
+    @DeleteMapping("/unfollow/{followMemberId}")
     public ResponseEntity<Void> unfollowMember(
             HttpServletRequest request,
             @AuthenticationPrincipal UserDetails userDetails,
-            @PathVariable Long memberId) {
+            @PathVariable Long followMemberId) {
 
         logInfo(request, "사용자 언팔로우");
 
-        memberService.unfollowMember(userDetails, memberId);
+        memberService.unfollowMember(userDetails, followMemberId);
 
         return ResponseEntity.ok().build();
     }

--- a/user-service/src/main/java/org/jnjeaaaat/domain/member/controller/MemberController.java
+++ b/user-service/src/main/java/org/jnjeaaaat/domain/member/controller/MemberController.java
@@ -39,5 +39,31 @@ public class MemberController {
         );
     }
 
+    @PostMapping("/follow/{memberId}")
+    public ResponseEntity<Void> followMember(
+            HttpServletRequest request,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long memberId) {
+
+        logInfo(request, "사용자 팔로우");
+
+        memberService.followMember(userDetails, memberId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/unfollow/{memberId}")
+    public ResponseEntity<Void> unfollowMember(
+            HttpServletRequest request,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long memberId) {
+
+        logInfo(request, "사용자 언팔로우");
+
+        memberService.unfollowMember(userDetails, memberId);
+
+        return ResponseEntity.ok().build();
+    }
+
 
 }

--- a/user-service/src/main/java/org/jnjeaaaat/domain/member/entity/Follow.java
+++ b/user-service/src/main/java/org/jnjeaaaat/domain/member/entity/Follow.java
@@ -1,0 +1,38 @@
+package org.jnjeaaaat.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "follower_id", nullable = false)
+    private Member follower;
+
+    @ManyToOne
+    @JoinColumn(name = "following_id", nullable = false)
+    private Member following;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Follow(Member follower, Member following) {
+        this.follower = follower;
+        this.following = following;
+    }
+}

--- a/user-service/src/main/java/org/jnjeaaaat/domain/member/repository/FollowRepository.java
+++ b/user-service/src/main/java/org/jnjeaaaat/domain/member/repository/FollowRepository.java
@@ -1,0 +1,15 @@
+package org.jnjeaaaat.domain.member.repository;
+
+import org.jnjeaaaat.domain.member.entity.Follow;
+import org.jnjeaaaat.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    Optional<Follow> findByFollowerAndFollowing(Member follower, Member following);
+    boolean existsByFollowerAndFollowing(Member follower, Member following);
+    void deleteByFollowerAndFollowing(Member follower, Member following);
+}

--- a/user-service/src/main/java/org/jnjeaaaat/domain/member/service/MemberService.java
+++ b/user-service/src/main/java/org/jnjeaaaat/domain/member/service/MemberService.java
@@ -100,20 +100,20 @@ public class MemberService {
     /**
      * Follow Member
      *
-     * @param userDetails @AuthenticationPrincipal 엑세스 토큰 값으로 추출한 User 객체
-     * @param memberId    @PathVariable 값으로 userDetails.getUsername() 비교를 위한 Member PK
+     * @param userDetails    @AuthenticationPrincipal 엑세스 토큰 값으로 추출한 User 객체
+     * @param followMemberId @PathVariable 값으로 userDetails.getUsername() 비교를 위한 Member PK
      */
     @Transactional
-    public void followMember(UserDetails userDetails, Long memberId) {
+    public void followMember(UserDetails userDetails, Long followMemberId) {
         Member follower = memberRepository.findById(Long.valueOf(userDetails.getUsername()))
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
-        Member following = memberRepository.findById(memberId)
+        Member following = memberRepository.findById(followMemberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
         validateFollowInfo(follower, following);
 
-        redisCountService.checkCount(Long.valueOf(userDetails.getUsername()), memberId, CountType.FOLLOW);
+        redisCountService.checkCount(Long.valueOf(userDetails.getUsername()), followMemberId, CountType.FOLLOW);
 
         followRepository.save(
                 Follow.builder()
@@ -136,21 +136,21 @@ public class MemberService {
     /**
      * Unfollow Member
      *
-     * @param userDetails @AuthenticationPrincipal 엑세스 토큰 값으로 추출한 User 객체
-     * @param memberId    @PathVariable 값으로 userDetails.getUsername() 비교를 위한 Member PK
+     * @param userDetails    @AuthenticationPrincipal 엑세스 토큰 값으로 추출한 User 객체
+     * @param followMemberId @PathVariable 값으로 userDetails.getUsername() 비교를 위한 Member PK
      */
     @Transactional
-    public void unfollowMember(UserDetails userDetails, Long memberId) {
+    public void unfollowMember(UserDetails userDetails, Long followMemberId) {
         Member follower = memberRepository.findById(Long.valueOf(userDetails.getUsername()))
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
-        Member following = memberRepository.findById(memberId)
+        Member following = memberRepository.findById(followMemberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
         Follow followInfo = followRepository.findByFollowerAndFollowing(follower, following)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_FOLLOW));
 
-        redisCountService.checkCount(Long.valueOf(userDetails.getUsername()), memberId, CountType.FOLLOW);
+        redisCountService.checkCount(Long.valueOf(userDetails.getUsername()), followMemberId, CountType.FOLLOW);
 
         followRepository.deleteByFollowerAndFollowing(followInfo.getFollower(), followInfo.getFollowing());
     }

--- a/user-service/src/main/java/org/jnjeaaaat/domain/member/service/RedisCountService.java
+++ b/user-service/src/main/java/org/jnjeaaaat/domain/member/service/RedisCountService.java
@@ -1,0 +1,32 @@
+package org.jnjeaaaat.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.domain.member.type.CountType;
+import org.jnjeaaaat.exception.MemberException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisCountService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void checkCount(Long loginMemberId, Long targetMemberId, CountType countType) {
+        String key = "member:" + loginMemberId + ":" + countType.getType() + ":" + targetMemberId;
+        Long count = redisTemplate.opsForValue().increment(key);
+
+        if (count == 1) {
+            redisTemplate.expire(key, Duration.ofMinutes(1));
+        }
+
+        if (count > 5) {
+            throw new MemberException(countType.getLimitExceededError());
+        }
+
+    }
+}

--- a/user-service/src/main/java/org/jnjeaaaat/domain/member/type/CountType.java
+++ b/user-service/src/main/java/org/jnjeaaaat/domain/member/type/CountType.java
@@ -1,0 +1,16 @@
+package org.jnjeaaaat.domain.member.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jnjeaaaat.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum CountType {
+
+    FOLLOW("follow", ErrorCode.FOLLOW_LIMIT_EXCEEDED),
+    BLOCK("block", ErrorCode.BLOCK_LIMIT_EXCEEDED);
+
+    private final String type;
+    private final ErrorCode limitExceededError;
+}

--- a/user-service/src/test/java/org/jnjeaaaat/domain/member/service/MemberServiceTest.java
+++ b/user-service/src/test/java/org/jnjeaaaat/domain/member/service/MemberServiceTest.java
@@ -2,8 +2,11 @@ package org.jnjeaaaat.domain.member.service;
 
 import org.jnjeaaaat.domain.member.dto.request.UpdateMemberRequest;
 import org.jnjeaaaat.domain.member.dto.response.UpdateMemberResponse;
+import org.jnjeaaaat.domain.member.entity.Follow;
 import org.jnjeaaaat.domain.member.entity.Member;
+import org.jnjeaaaat.domain.member.repository.FollowRepository;
 import org.jnjeaaaat.domain.member.repository.MemberRepository;
+import org.jnjeaaaat.domain.member.type.CountType;
 import org.jnjeaaaat.domain.member.type.MemberRole;
 import org.jnjeaaaat.exception.MemberException;
 import org.jnjeaaaat.global.security.CustomUserDetailsService;
@@ -30,14 +33,20 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.jnjeaaaat.global.cons.FixedData.FIXED_TIME;
 import static org.jnjeaaaat.global.cons.FixedData.TEST_IMAGE_FILE_PATH;
 import static org.jnjeaaaat.global.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
     @Mock
     MemberRepository memberRepository;
+
+    @Mock
+    FollowRepository followRepository;
 
     @Mock
     CustomUserDetailsService customUserDetailsService;
@@ -47,6 +56,9 @@ class MemberServiceTest {
 
     @Mock
     StorageService storageService;
+
+    @Mock
+    RedisCountService redisCountService;
 
     @InjectMocks
     MemberService memberService;
@@ -153,6 +165,220 @@ class MemberServiceTest {
                             imageFile))
                     .isInstanceOf(MemberException.class)
                     .hasMessageContaining(AUTHENTICATION_MEMBER_MISMATCH.getErrorMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 팔로우")
+    class FollowMemberTest {
+
+        Member follower = createMockMember(); // ID 1
+        Member following = createMockMember(); // ID 2
+
+        @Test
+        @DisplayName("[성공] 사용자 팔로우 - 팔로우 관계 생성")
+        void success_follow_when_valid_request() {
+            // given
+            ReflectionTestUtils.setField(following, "id", 2L);
+
+            given(userDetails.getUsername()).willReturn("1");
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(memberRepository.findById(following.getId())).willReturn(Optional.of(following));
+            given(followRepository.existsByFollowerAndFollowing(follower, following)).willReturn(false);
+            doNothing().when(redisCountService).checkCount(follower.getId(), following.getId(), CountType.FOLLOW);
+            given(followRepository.save(any(Follow.class))).willReturn(
+                    Follow.builder()
+                            .follower(follower)
+                            .following(following)
+                            .build()
+            );
+            // when
+            // then
+            assertDoesNotThrow(() -> memberService.followMember(userDetails, following.getId()));
+
+            // verify
+            verify(memberRepository).findById(follower.getId());
+            verify(memberRepository).findById(following.getId());
+            verify(followRepository).existsByFollowerAndFollowing(follower, following);
+            verify(redisCountService).checkCount(follower.getId(), following.getId(), CountType.FOLLOW);
+            verify(followRepository).save(any(Follow.class));
+        }
+
+        @Test
+        @DisplayName("[실패] 사용자 팔로우 - 팔로워 회원을 찾을 수 없음")
+        void fail_follow_when_not_found_follower() {
+            // given
+            given(userDetails.getUsername()).willReturn("1");
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.empty());
+            // when
+            // then
+            assertThatThrownBy(() -> memberService.followMember(userDetails, following.getId()))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(NOT_FOUND_MEMBER.getErrorMessage());
+        }
+
+        @Test
+        @DisplayName("[실패] 사용자 팔로우 - 팔로잉 대상 회원을 찾을 수 없음")
+        void fail_follow_when_not_found_following() {
+            // given
+
+            // when
+            given(userDetails.getUsername()).willReturn("1");
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(memberRepository.findById(following.getId())).willReturn(Optional.empty());
+
+            // then
+            assertThatThrownBy(() -> memberService.followMember(userDetails, following.getId()))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(NOT_FOUND_MEMBER.getErrorMessage());
+
+            // verify
+            verify(memberRepository).findById(follower.getId());
+            verify(memberRepository).findById(following.getId());
+            verify(followRepository, never()).save(any(Follow.class));
+        }
+
+        @Test
+        @DisplayName("[실패] 사용자 팔로우 - 자기 자신을 팔로우할 수 없음")
+        void fail_follow_when_cannot_follow_self() {
+            // given
+
+            // when
+            given(userDetails.getUsername()).willReturn("1");
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+
+            // then
+            assertThatThrownBy(() -> memberService.followMember(userDetails, 1L))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(CANNOT_FOLLOW_SELF.getErrorMessage());
+
+            // verify
+            verify(memberRepository, times(2)).findById(1L);
+            verify(followRepository, never()).save(any(Follow.class));
+        }
+
+        @Test
+        @DisplayName("[실패] 사용자 팔로우 - 이미 팔로우한 사용자")
+        void fail_follow_when_already_following_member() {
+            // given
+            ReflectionTestUtils.setField(following, "id", 2L);
+
+            given(userDetails.getUsername()).willReturn(follower.getId().toString());
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(memberRepository.findById(following.getId())).willReturn(Optional.of(following));
+            given(followRepository.existsByFollowerAndFollowing(follower, following)).willReturn(true);
+
+            // when
+            // then
+            assertThatThrownBy(() -> memberService.followMember(userDetails, following.getId()))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(ALREADY_FOLLOWING_MEMBER.getErrorMessage());
+
+            // verify
+            verify(memberRepository).findById(follower.getId());
+            verify(memberRepository).findById(following.getId());
+            verify(followRepository).existsByFollowerAndFollowing(follower, following);
+            verify(followRepository, never()).save(any(Follow.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 언팔로우")
+    class UnfollowMemberTest {
+
+        Member follower = createMockMember(); // ID 1
+        Member following = createMockMember(); // ID 2
+
+        Follow followInfo = Follow.builder()
+                .follower(follower)
+                .following(following)
+                .build();
+
+        @Test
+        @DisplayName("[성공] 사용자 언팔로우")
+        void success_unfollow_when_valid_request() {
+            // given
+            ReflectionTestUtils.setField(following, "id", 2L);
+
+            // when
+            given(userDetails.getUsername()).willReturn("1");
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(memberRepository.findById(following.getId())).willReturn(Optional.of(following));
+            given(followRepository.findByFollowerAndFollowing(follower, following)).willReturn(Optional.of(followInfo));
+            doNothing().when(redisCountService).checkCount(follower.getId(), following.getId(), CountType.FOLLOW);
+            doNothing().when(followRepository).deleteByFollowerAndFollowing(follower, following);
+
+            // then
+            assertDoesNotThrow(() -> memberService.unfollowMember(userDetails, following.getId()));
+
+            // verify
+            verify(memberRepository).findById(follower.getId());
+            verify(memberRepository).findById(following.getId());
+            verify(followRepository).findByFollowerAndFollowing(follower, following);
+            verify(redisCountService).checkCount(follower.getId(), following.getId(), CountType.FOLLOW);
+            verify(followRepository).deleteByFollowerAndFollowing(follower, following);
+        }
+
+        @Test
+        @DisplayName("[실패] 사용자 언팔로우 - 팔로워 회원을 찾을 수 없음")
+        void fail_unfollow_when_follower_not_found() {
+            // given
+            given(userDetails.getUsername()).willReturn("1");
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> memberService.unfollowMember(userDetails, following.getId()))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(NOT_FOUND_MEMBER.getErrorMessage());
+
+            // verify
+            verify(memberRepository).findById(follower.getId());
+            verify(followRepository, never()).deleteByFollowerAndFollowing(any(Member.class), any(Member.class));
+        }
+
+        @Test
+        @DisplayName("[실패] 사용자 언팔로우 - 팔로잉 대상 회원을 찾을 수 없음")
+        void fail_unfollow_when_following_not_found() {
+            // given
+            given(userDetails.getUsername()).willReturn("1");
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(memberRepository.findById(following.getId())).willReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> memberService.unfollowMember(userDetails, following.getId()))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(NOT_FOUND_MEMBER.getErrorMessage());
+
+            // verify
+            verify(memberRepository).findById(follower.getId());
+            verify(memberRepository).findById(following.getId());
+            verify(followRepository, never()).deleteByFollowerAndFollowing(any(Member.class), any(Member.class));
+        }
+
+        @Test
+        @DisplayName("[실패] 사용자 언팔로우 - 팔로우 관계가 존재하지 않음")
+        void fail_unfollow_when_not_found_follow() {
+            // given
+            ReflectionTestUtils.setField(following, "id", 2L);
+
+            given(userDetails.getUsername()).willReturn("1");
+            given(memberRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(memberRepository.findById(following.getId())).willReturn(Optional.of(following));
+            given(followRepository.findByFollowerAndFollowing(follower, following)).willReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> memberService.unfollowMember(userDetails, following.getId()))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(NOT_FOUND_FOLLOW.getErrorMessage());
+
+            // verify
+            verify(memberRepository).findById(follower.getId());
+            verify(memberRepository).findById(following.getId());
+            verify(followRepository).findByFollowerAndFollowing(follower, following);
+            verify(followRepository, never()).deleteByFollowerAndFollowing(any(Member.class), any(Member.class));
         }
     }
 


### PR DESCRIPTION
## Changes
### user-service module
- **Follow Entity**
  - `Member follower, Member following` Column 등록
- **MemberController**
  - `[POST] /api/members/follow/{followMemberId}`
  - followMember(`@PathVariable` followMemberId)
  - `[DELETE] /api/members/follow/{followMemberId}`
  - unfollowMember(`@PathVariable` followMemberId)
- **FollowRepository**
  - existsFollowInfo(), deleteFollowInfo()
- **RedisCountService**
  - 팔로우, 언팔로우 연속실행 방지를 위한
  - `RedisTemplate.increment() > 5` 일때 에러메세지 반환
  - CountType으로 FOLLOW, BLOCK 구별
  - `CountType 안에서 ErrorCode 설정` (if문으로 구별하지 않고)

### test
- follow(), unfollow() 테스트 케이스 작성

## Background
알림 기능을 만들기 전 알림을 보내는 조건을 만들기 위해 Follow 기능을 추가했습니다.
다른 사용자가 나를 팔로우했을때, 팔로우한 사용자가 게시글을 올렸을때 알림 보낼 예정

## Discuss
팔로우, 차단 등 사용자 간의 관계를 정의하는 기능은 전에도 많이 해봤지만 횟수 제한을 걸어본건 처음이었습니다.
isFollowing, isBlocking 처럼 boolean 값으로 상태를 나타내는 컬럼을 만들어서 `db에서 라인 자체를 삭제하지 않도록 했었는데 비효율적`이라는 것을 이번에 알았습니다.

## related issue
#45

## Execute
**ID:1 Member가 ID:2 Member를 follow, unfollow 하려는 상황**

1. 1분동안 연속으로 팔로우, 언팔로우를 6번 이상 했을때 에러 메세지 반환
2. Redis server count value 확인

### 1분 동안 연속으로 팔로우, 언팔로우 6번 이상 후 에러 메세지 확인
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/b1244527-e3b4-4ecc-b202-982efff7ccd0" />

### Redis service count value 6 인지 확인
RedisTemplate에 key값은 "member:{followerId}:follow:{followingId}"
![image](https://github.com/user-attachments/assets/eda6b195-38a8-4dc8-bed0-f1e7a8a2b9a2)
